### PR TITLE
Return a Bool from Barricade.selectResponse(for:with:) representing whether a response was found

### DIFF
--- a/BarricadeKit/Core/Barricade.swift
+++ b/BarricadeKit/Core/Barricade.swift
@@ -67,10 +67,17 @@ open class Barricade: URLProtocol {
     public static func unregister(set: ResponseSet) {
         responseStore.unregister(set: set)
     }
-    
-    public static func selectResponse(for request: String, with name: String) {
-        guard let set = responseStore.responseSet(for: request) else { return }
-        responseStore.selectCurrentResponse(in: set, named: name)
+
+    /**
+     Tells Barricade to set a response object to be returned the next time the request is sent.
+     - Parameters:
+       - request: The operation name for the request
+       - name: The display name of the response
+     - Returns: Whether or not there was a response object found in the response store for the provided request operation name
+    */
+    @discardableResult public static func selectResponse(for request: String, with name: String) -> Bool {
+        guard let set = responseStore.responseSet(for: request) else { return false }
+        return responseStore.selectCurrentResponse(in: set, named: name)
     }
     
     public static func resetSelections() {

--- a/BarricadeKit/Core/ResponseStore/ResponseStore.swift
+++ b/BarricadeKit/Core/ResponseStore/ResponseStore.swift
@@ -23,7 +23,7 @@ public protocol ResponseStore {
     
     func responseSet(for requestNamed: String) -> ResponseSet?
     
-    func selectCurrentResponse(in set: ResponseSet, named: String)
+    @discardableResult func selectCurrentResponse(in set: ResponseSet, named: String) -> Bool
     
     func unregister(set: ResponseSet)
     
@@ -82,9 +82,10 @@ public class InMemoryResponseStore: ResponseStore {
         return current
     }
     
-    public func selectCurrentResponse(in set: ResponseSet, named: String) {
-        guard let response = set.response(named: named) else { return }
+    @discardableResult public func selectCurrentResponse(in set: ResponseSet, named: String) -> Bool {
+        guard let response = set.response(named: named) else { return false }
         currentResponseForSet[set.requestName] = response
+        return true
     }
     
     public func resetSelections() {

--- a/BarricadeKit/Test/BarricadeTests.swift
+++ b/BarricadeKit/Test/BarricadeTests.swift
@@ -66,9 +66,20 @@ class BarricadeTests: XCTestCase {
         waitForExpectations(timeout: 2.0, handler: nil)
     }
     
-    
+    func testReturnedTrueForFoundResponse() {
+        Barricade.register(set: .make())
+        let result = Barricade.selectResponse(for: "login", with: "anything")
+        XCTAssertTrue(result)
+    }
+
+    func testReturnedFalseForMissingResponse() {
+        let result = Barricade.selectResponse(for: "missingOperation", with: "anything")
+        XCTAssertFalse(result)
+    }
+
+
     // MARK: Errors
-    
+
     func testNoResponseRegistered() {
         let completionExpectation = expectation(description: "request completed")
         let urlRequest = URLRequest(url: URL(string: "http://example.com")!)

--- a/BarricadeKit/Test/ResponseStore/InMemoryResponseStoreTests.swift
+++ b/BarricadeKit/Test/ResponseStore/InMemoryResponseStoreTests.swift
@@ -47,6 +47,17 @@ class InMemoryResponseStoreTests: XCTestCase {
         XCTAssertEqual(responseStore.responseSets[0].requestName, "B")
     }
     
+    func testReturnedTrueForFoundResponse() {
+        responseStore.register(set: .makeSetA())
+        let result = responseStore.selectCurrentResponse(in: .makeSetA(), named: "success")
+        XCTAssertTrue(result)
+    }
+
+    func testReturnedFalseForMissingResponse() {
+        let result = responseStore.selectCurrentResponse(in: .makeSetA(), named: "missingResponse")
+        XCTAssertFalse(result)
+    }
+
     
     // MARK: Selection Management
     


### PR DESCRIPTION
This Boolean result may be useful when using Barricade to dynamically update the response mapped to a request at runtime.